### PR TITLE
Persist settings configuration across sessions (save last used config)

### DIFF
--- a/FreqFreak/MainWindow.xaml.cs
+++ b/FreqFreak/MainWindow.xaml.cs
@@ -90,7 +90,8 @@ namespace FreqFreak
         {
             dragHandler = new(this);
             Visualizer.MainWin = this;
-            Visualizer.InstanceOptions.SetDefaults();
+            Visualizer.InstanceOptions.SetDefaults(); // Set defaults first
+            LoadConfig(); // Then override with saved values
             InitializeComponent();
 
             Loaded += (_, __) => _hwnd = new WindowInteropHelper(this).Handle;
@@ -152,6 +153,8 @@ namespace FreqFreak
             {
                 CreateNewOptionsWindow();
             };
+
+            this.Closed += (_, __) => SaveConfig();
         }
         private void MainWindow_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
         {
@@ -1602,6 +1605,43 @@ namespace FreqFreak
             _cts.Cancel();
             _trayIcon?.Dispose();
             _icon?.Dispose();
+        }
+
+        private const string ConfigFilePath = "FreqFreakConfig.json";
+
+        // Save settings
+        private void SaveConfig()
+        {
+            try
+            {
+                var json = JsonConvert.SerializeObject(Visualizer.InstanceOptions, Formatting.Indented);
+                File.WriteAllText(ConfigFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Failed to save config: " + ex.Message);
+            }
+        }
+
+        // Load settings
+        private void LoadConfig()
+        {
+            try
+            {
+                if (File.Exists(ConfigFilePath))
+                {
+                    var json = File.ReadAllText(ConfigFilePath);
+                    var options = JsonConvert.DeserializeObject<Settings>(json);
+                    if (options != null)
+                    {
+                        Visualizer.InstanceOptions = options;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Failed to load config: " + ex.Message);
+            }
         }
     }
 }


### PR DESCRIPTION
Hi Epsi,

First, thank you for making this program, I'm really enjoying using it.

I found a missing (but useful) feature while using FreqFreak and a made a rudimentary attempt to **introduce basic persistence for visualizer settings** by saving/loading them from a `FreqFreakConfig.json` file. I tested the changes and it seems to work mostly fine, though I haven't yet verified behavior across a full PC restart.

The idea is that, for example, if FreqFreak is placed in the startup folder, it can launch with the last-used configuration without requiring a manual import each time.

That said, there are still some rough edges:
- The “Preview” checkbox should ideally default to enabled.
- There could be an option/toggle to disable auto-reload for users who prefer manual control.
- The visualizer's screen position isn't being persisted yet (it always resets near the center). I tried but couldn't quite get it working.
- Some styling options (like `Color1` when using Solid Color mode) don't import correctly, unless the style is Gradient.
- It might also be nice to hide the overlay icon from the taskbar, leaving only the cogwheel in the system tray (though that's probably best left for another issue/PR).

Thanks again for your time and for creating such a cool and customizable tool!